### PR TITLE
Enforce consistent config handling for services

### DIFF
--- a/services/sensu-agent/systemd/etc/systemd/system/sensu-agent.service
+++ b/services/sensu-agent/systemd/etc/systemd/system/sensu-agent.service
@@ -2,7 +2,6 @@
 Description=The Sensu Agent process.
 After=network-online.target
 Wants=network-online.target
-ConditionPathExists=/etc/sensu/agent.yml
 
 [Service]
 Type=simple

--- a/services/sensu-backend/systemd/etc/systemd/system/sensu-backend.service
+++ b/services/sensu-backend/systemd/etc/systemd/system/sensu-backend.service
@@ -2,7 +2,6 @@
 Description=The Sensu Backend service.
 After=network-online.target
 Wants=network-online.target
-ConditionPathExists=/etc/sensu/backend.yml
 
 [Service]
 Type=simple


### PR DESCRIPTION
This commit makes the sensu-backend and sensu-agent services consistent
in their expectations and handling of the /etc/sensu/{backend,agent}.yml
config files.

With systemd, the ConditionPathExists feature has been applied so that
if the configuration file is missing, the service will not start up.

sensu-agent has been modified to use an explicit path to a configuration
file. This should prevent issues with invalid configuration. (See
sensu-packaging #9) This has been done in both systemd and sysvinit.

Closes #9 