### PR TITLE
Add debian/bullseye to package repository list

### DIFF
--- a/cmake/packaging/sensu-agent/386.cmake
+++ b/cmake/packaging/sensu-agent/386.cmake
@@ -30,7 +30,8 @@ function(build_sensu_agent_linux_386_deb_package)
         "ubuntu/focal"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/amd64.cmake
+++ b/cmake/packaging/sensu-agent/amd64.cmake
@@ -38,7 +38,8 @@ function(build_sensu_agent_linux_amd64_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/arm64.cmake
+++ b/cmake/packaging/sensu-agent/arm64.cmake
@@ -37,7 +37,8 @@ function(build_sensu_agent_linux_arm64_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/arm_5.cmake
+++ b/cmake/packaging/sensu-agent/arm_5.cmake
@@ -16,7 +16,8 @@ function(build_sensu_agent_linux_arm_5_deb_package)
     set(PACKAGECLOUD_DISTROS
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/arm_7.cmake
+++ b/cmake/packaging/sensu-agent/arm_7.cmake
@@ -37,7 +37,8 @@ function(build_sensu_agent_linux_arm_7_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/mips64le_hardfloat.cmake
+++ b/cmake/packaging/sensu-agent/mips64le_hardfloat.cmake
@@ -15,7 +15,8 @@ function(build_sensu_agent_linux_mips64le_hardfloat_deb_package)
 
     set(PACKAGECLOUD_DISTROS
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/mipsle_hardfloat.cmake
+++ b/cmake/packaging/sensu-agent/mipsle_hardfloat.cmake
@@ -16,7 +16,8 @@ function(build_sensu_agent_linux_mipsle_hardfloat_deb_package)
     set(PACKAGECLOUD_DISTROS
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/ppc64le.cmake
+++ b/cmake/packaging/sensu-agent/ppc64le.cmake
@@ -31,7 +31,8 @@ function(build_sensu_agent_linux_ppc64le_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/s390x.cmake
+++ b/cmake/packaging/sensu-agent/s390x.cmake
@@ -32,7 +32,8 @@ function(build_sensu_agent_linux_s390x_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-backend/amd64.cmake
+++ b/cmake/packaging/sensu-backend/amd64.cmake
@@ -38,7 +38,8 @@ function(build_sensu_backend_linux_amd64_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-backend/arm64.cmake
+++ b/cmake/packaging/sensu-backend/arm64.cmake
@@ -37,7 +37,8 @@ function(build_sensu_backend_linux_arm64_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-backend/ppc64le.cmake
+++ b/cmake/packaging/sensu-backend/ppc64le.cmake
@@ -31,7 +31,8 @@ function(build_sensu_backend_linux_ppc64le_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-cli/386.cmake
+++ b/cmake/packaging/sensu-cli/386.cmake
@@ -30,7 +30,8 @@ function(build_sensu_cli_linux_386_deb_package)
         "ubuntu/focal"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/amd64.cmake
+++ b/cmake/packaging/sensu-cli/amd64.cmake
@@ -38,7 +38,8 @@ function(build_sensu_cli_linux_amd64_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/arm64.cmake
+++ b/cmake/packaging/sensu-cli/arm64.cmake
@@ -36,7 +36,8 @@ function(build_sensu_cli_linux_arm64_deb_package)
         "ubuntu/focal"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/arm_5.cmake
+++ b/cmake/packaging/sensu-cli/arm_5.cmake
@@ -16,7 +16,8 @@ function(build_sensu_cli_linux_arm_5_deb_package)
     set(PACKAGECLOUD_DISTROS
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/arm_7.cmake
+++ b/cmake/packaging/sensu-cli/arm_7.cmake
@@ -37,7 +37,8 @@ function(build_sensu_cli_linux_arm_7_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/mips64le_hardfloat.cmake
+++ b/cmake/packaging/sensu-cli/mips64le_hardfloat.cmake
@@ -15,7 +15,8 @@ function(build_sensu_cli_linux_mips64le_hardfloat_deb_package)
 
     set(PACKAGECLOUD_DISTROS
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/mipsle_hardfloat.cmake
+++ b/cmake/packaging/sensu-cli/mipsle_hardfloat.cmake
@@ -16,7 +16,8 @@ function(build_sensu_cli_linux_mipsle_hardfloat_deb_package)
     set(PACKAGECLOUD_DISTROS
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/ppc64le.cmake
+++ b/cmake/packaging/sensu-cli/ppc64le.cmake
@@ -31,7 +31,8 @@ function(build_sensu_cli_linux_ppc64le_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/s390x.cmake
+++ b/cmake/packaging/sensu-cli/s390x.cmake
@@ -32,7 +32,8 @@ function(build_sensu_cli_linux_s390x_deb_package)
         "ubuntu/hirsute"
         "debian/jessie"
         "debian/stretch"
-        "debian/buster")
+        "debian/buster"
+        "debian/bullseye")
 
     set_common_settings()
     set_sensu_cli_settings()


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Adds `debian/bullseye` to the list of package repositories we upload packages to. This was requested by a customer as per @agoddard.

Currently supported architectures are listed on the release page: https://www.debian.org/releases/bullseye/