### PR TITLE
Fix support for multiple groups in sysvinit scripts

### DIFF
--- a/services/sensu-agent/sysvinit/etc/init.d/sensu-agent
+++ b/services/sensu-agent/sysvinit/etc/init.d/sensu-agent
@@ -57,7 +57,7 @@ start() {
   # If groups not already defined pull in configured groups for sensu user
   #  See chroot --help for info on groups
   #  must conform to syntax like: 'g1,g2,g3'
-  [ -z "$groups" ] && groups=$(groups $user | cut -d ":" -f2 | tr ' ' "," | tail -c+2)
+  [ -z "$groups" ] && groups=$(id --groups --name $user | tr ' ' ',')
 
   # Run the program!
 

--- a/services/sensu-backend/sysvinit/etc/init.d/sensu-backend
+++ b/services/sensu-backend/sysvinit/etc/init.d/sensu-backend
@@ -57,8 +57,7 @@ start() {
   # If groups not already defined pull in configured groups for sensu user
   #  See chroot --help for info on groups
   #  must conform to syntax like: 'g1,g2,g3'
-  [ -z "$groups" ] && groups=$(groups $user | cut -d ":" -f2 | tr ' ' "," | tail -c+2)
-
+  [ -z "$groups" ] && groups=$(id --groups --name $user | tr ' ' ',')
 
   # Run the program!
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The output of the previous commands in the script did not comma-separate the names of groups, despite the comment stating that they were required to. This fixes the output when a user belongs to multiple groups.

​I reproduced the bug by creating 3 groups and adding the Sensu user to them:
​
addgroup testgroup1​
​addgroup testgroup2
​addgroup testgroup3
usermod -G testgroup1,testgroup2,testgroup3 sensu
​
​I then started sensu-backend and then checked which groups the process was running as:
​
​/etc/init.d/sensu-backend start
​cat /proc/$(pidof sensu-backend)/status | grep Groups
Groups: 998 1000 

Group 998 is sensu and 1000 is testgroup 1 which confirms that the bug exists.
​
​After applying the patch all four groups show up:
​
​cat /proc/$(pidof sensu-backend)/status | grep Groups
Groups: 998 1000 1001 1002