### PR TITLE
Add el/9 & fedora/36

### DIFF
--- a/cmake/packaging/sensu-agent/amd64.cmake
+++ b/cmake/packaging/sensu-agent/amd64.cmake
@@ -9,12 +9,14 @@ function(build_sensu_agent_linux_amd64_rpm_package)
         "el/6"
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "feodra/36")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/arm64.cmake
+++ b/cmake/packaging/sensu-agent/arm64.cmake
@@ -8,12 +8,14 @@ function(build_sensu_agent_linux_arm64_rpm_package)
     set(PACKAGECLOUD_DISTROS
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/arm_7.cmake
+++ b/cmake/packaging/sensu-agent/arm_7.cmake
@@ -12,7 +12,8 @@ function(build_sensu_agent_linux_arm_7_rpm_package)
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/ppc64le.cmake
+++ b/cmake/packaging/sensu-agent/ppc64le.cmake
@@ -7,7 +7,9 @@ function(build_sensu_agent_linux_ppc64le_rpm_package)
 
     set(PACKAGECLOUD_DISTROS
         "el/8"
-        "fedora/35")
+        "el/9"
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-agent/s390x.cmake
+++ b/cmake/packaging/sensu-agent/s390x.cmake
@@ -9,7 +9,9 @@ function(build_sensu_agent_linux_s390x_rpm_package)
         "el/6"
         "el/7"
         "el/8"
-        "fedora/35")
+        "el/9"
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_agent_settings()

--- a/cmake/packaging/sensu-backend/amd64.cmake
+++ b/cmake/packaging/sensu-backend/amd64.cmake
@@ -9,12 +9,14 @@ function(build_sensu_backend_linux_amd64_rpm_package)
         "el/6"
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-backend/arm64.cmake
+++ b/cmake/packaging/sensu-backend/arm64.cmake
@@ -8,12 +8,14 @@ function(build_sensu_backend_linux_arm64_rpm_package)
     set(PACKAGECLOUD_DISTROS
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-backend/ppc64le.cmake
+++ b/cmake/packaging/sensu-backend/ppc64le.cmake
@@ -7,7 +7,9 @@ function(build_sensu_backend_linux_ppc64le_rpm_package)
 
     set(PACKAGECLOUD_DISTROS
         "el/8"
-        "fedora/35")
+        "el/9"
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_backend_settings()

--- a/cmake/packaging/sensu-cli/amd64.cmake
+++ b/cmake/packaging/sensu-cli/amd64.cmake
@@ -9,12 +9,14 @@ function(build_sensu_cli_linux_amd64_rpm_package)
         "el/6"
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/arm64.cmake
+++ b/cmake/packaging/sensu-cli/arm64.cmake
@@ -8,12 +8,14 @@ function(build_sensu_cli_linux_arm64_rpm_package)
     set(PACKAGECLOUD_DISTROS
         "el/7"
         "el/8"
+        "el/9"
         "fedora/30"
         "fedora/31"
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/arm_7.cmake
+++ b/cmake/packaging/sensu-cli/arm_7.cmake
@@ -12,7 +12,8 @@ function(build_sensu_cli_linux_arm_7_rpm_package)
         "fedora/32"
         "fedora/33"
         "fedora/34"
-        "fedora/35")
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/ppc64le.cmake
+++ b/cmake/packaging/sensu-cli/ppc64le.cmake
@@ -7,7 +7,9 @@ function(build_sensu_cli_linux_ppc64le_rpm_package)
 
     set(PACKAGECLOUD_DISTROS
         "el/8"
-        "fedora/35")
+        "el/9"
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_cli_settings()

--- a/cmake/packaging/sensu-cli/s390x.cmake
+++ b/cmake/packaging/sensu-cli/s390x.cmake
@@ -9,7 +9,9 @@ function(build_sensu_cli_linux_s390x_rpm_package)
         "el/6"
         "el/7"
         "el/8"
-        "fedora/35")
+        "el/9"
+        "fedora/35"
+        "fedora/36")
 
     set_common_settings()
     set_sensu_cli_settings()


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

RHEL 9 & Fedora 36 were recently released. This PR adds them to the list of distros we upload packages for.